### PR TITLE
[fix] Resolve SEO issue with blogs' page duplication

### DIFF
--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -43,7 +43,7 @@ const Card = ({ categories, description, image, slug, title, views }) => {
         )}
 
         <Text as="h3" size={6} className="title" truncate>
-          <Link href={blogUrl}>{title}</Link>
+          <Link href={blogUrl} rel='canonical'>{title}</Link>
         </Text>
         <Text
           size={2}


### PR DESCRIPTION
- Resolved SEO issue with blogs' page duplication

Pages for articles don’t specify their canonical version, which results in duplicates.
Similar or duplicate pages of the website must have a canonical attribute to instruct search engines to show the most authoritative (canonical) version of the page in search results.